### PR TITLE
Remove redundant 'rdf' in looks_like_feed?

### DIFF
--- a/lib/feedbag.rb
+++ b/lib/feedbag.rb
@@ -161,7 +161,7 @@ class Feedbag
   end
 
   def looks_like_feed?(url)
-    if url =~ /(\.(rdf|xml|rdf|rss)$|feed=(rss|atom)|(atom|feed)\/?$)/i
+    if url =~ /(\.(rdf|xml|rss)$|feed=(rss|atom)|(atom|feed)\/?$)/i
       true
     else
       false


### PR DESCRIPTION
The 'rdf' in the regex of looks_like_feed?(url) seems to be redundant so I removed it.
