### PR TITLE
Follow redirects

### DIFF
--- a/lib/feedbag.rb
+++ b/lib/feedbag.rb
@@ -9,10 +9,10 @@
 # distribute, sublicense, and/or sell copies of the Software, and to
 # permit persons to whom the Software is furnished to do so, subject to
 # the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND

--- a/lib/feedbag.rb
+++ b/lib/feedbag.rb
@@ -24,6 +24,7 @@
 require "rubygems"
 require "nokogiri"
 require "open-uri"
+require "open_uri_redirections"
 require "net/http"
 
 class Feedbag
@@ -95,7 +96,7 @@ class Feedbag
     end
 
     begin
-      html = open(url) do |f|
+      html = open(url, allow_redirections: :all)
         content_type = f.content_type.downcase
         if content_type == "application/octet-stream" # open failed
           content_type = f.meta["content-type"].gsub(/;.*$/, '')


### PR DESCRIPTION
Before:

```
=> Feedbag.find("http://wordpress.com")
=> RuntimeError error occurred with: `http://wordpress.com': redirection forbidden: http://wordpress.com -> https://wordpress.com/
```

After:

```
=> Feedbag.find("http://wordpress.com")
=> ["http://blog.wordpress.com/feed/", "http://freshlypressed.wordpress.com/feed/"]
```