### PR TITLE
Allow URL redirect from/to http and https

### DIFF
--- a/feedbag.gemspec
+++ b/feedbag.gemspec
@@ -2,21 +2,22 @@
 
 Gem::Specification.new do |s|
   s.name = %q{feedbag}
-  s.version = "0.9.5"
+  s.version = "0.9.6"
   s.homepage = "http://github.com/damog/feedbag"
   s.rubyforge_project = "feedbag"
   s.licenses = ["MIT"]
 
   s.authors = ["David Moreno", "Derek Willis"]
-  s.date = %q{2014-10-16}
-  s.description = %q{Ruby's favorite feed auto-discoverty tool}
+  s.date = %q{2016-04-11}
+  s.description = %q{Ruby's favorite feed auto-discovery tool}
   s.email = %q{david@axiombox.com}
   s.extra_rdoc_files = ["README.markdown", "COPYING"]
   s.files = ["lib/feedbag.rb", "benchmark/rfeedfinder_benchmark.rb", "bin/feedbag"]
   s.has_rdoc = true
   s.rdoc_options = ["--main", "README.markdown"]
   s.summary = %q{Ruby's favorite feed auto-discovery tool}
-  s.add_dependency('nokogiri', '~> 1.0') 
+  s.add_dependency('nokogiri', '~> 1.0')
+  s.add_dependency('open_uri_redirections', '~> 0.2')
   s.add_development_dependency 'shoulda', '~> 0'
   s.add_development_dependency 'mocha', '~> 0.12', '>= 0.12.0'
   s.bindir = 'bin'

--- a/lib/feedbag.rb
+++ b/lib/feedbag.rb
@@ -25,6 +25,7 @@ require "rubygems"
 require "nokogiri"
 require "open-uri"
 require "net/http"
+require "open_uri_redirections"
 
 class Feedbag
 
@@ -95,7 +96,7 @@ class Feedbag
     end
 
     begin
-      html = open(url) do |f|
+      html = open(url, :allow_redirections => :all) do |f|
         content_type = f.content_type.downcase
         if content_type == "application/octet-stream" # open failed
           content_type = f.meta["content-type"].gsub(/;.*$/, '')


### PR DESCRIPTION
This prevents getting "redirection forbidden" error when URL submitted through Feedbag redirects from https to http or vice versa. Uses open_uri_redirections gem.

Example:

```
pry(main)> Feedbag.find "https://oracle-base.com/blog/feed/"
RuntimeError error occurred with: `https://oracle-base.com/blog/feed/': redirection forbidden: https://oracle-base.com/blog/feed/ -> http://feeds.feedburner.com/TheOracleBaseBlog
```

New version:

```
pry(main)> Feedbag.find "https://oracle-base.com/blog/feed/"
=> ["https://oracle-base.com/blog/feed/"]
```