### PR TITLE
added params in look_like_feed regex

### DIFF
--- a/lib/feedbag.rb
+++ b/lib/feedbag.rb
@@ -162,7 +162,7 @@ class Feedbag
   end
 
   def looks_like_feed?(url)
-    if url =~ /(\.(rdf|xml|rss)$|feed=(rss|atom)|(atom|feed)\/?$)/i
+    if url =~ /(\.(rdf|xml|rss)(\?([\w'\-%]?(=[\w'\-%.]*)?(&|#)?)+)?(:[\w'\-%]+)?$|feed=(rss|atom)|(atom|feed)\/?$)/i
       true
     else
       false

--- a/test/feedbag_test.rb
+++ b/test/feedbag_test.rb
@@ -33,4 +33,16 @@ class FeedbagTest < Test::Unit::TestCase
     end
   end
 
+  context "Feedbag#looks_like_feed? should assume that url with proper extension is a feed" do
+    setup do
+      @feeds = ['http://feeds.bbci.co.uk/news/rss.xml', 'http://feeds.bbci.co.uk/news/rss.rdf',
+                'http://feeds.bbci.co.uk/news/rss.rss', 'http://feeds.bbci.co.uk/news/rss.xml?edition=int']
+    end
+    should "return true" do
+      @feeds.each do |url|
+        assert Feedbag.new.looks_like_feed?(url)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Changed regex to recognize feed urls like `http://feeds.bbci.co.uk/news/rss.xml?edition=int`