### PR TITLE
Fix warning from OpenURI

### DIFF
--- a/lib/feedbag.rb
+++ b/lib/feedbag.rb
@@ -97,7 +97,7 @@ class Feedbag
     end
 
     begin
-      html = open(url, :allow_redirections => :all) do |f|
+      html = URI.open(url, :allow_redirections => :all) do |f|
         content_type = f.content_type.downcase
         if content_type == "application/octet-stream" # open failed
           content_type = f.meta["content-type"].gsub(/;.*$/, '')


### PR DESCRIPTION
URI.open is now called directly, which suppresses the following warning:

> warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open

Close #24 