### PR TITLE
Add the correct mime type for JSON Feed

### DIFF
--- a/lib/feedbag.rb
+++ b/lib/feedbag.rb
@@ -37,6 +37,7 @@ class Feedbag
     'application/rss+xml',
     'application/rdf+xml',
     'application/json',
+    'application/feed+json'
   ].freeze
 
   def self.feed?(url)


### PR DESCRIPTION
Hi there - JSON Feed should be served with the MIME type "application/feed+json" as documented here:  https://jsonfeed.org/version/1.1

This patch adds that MIME type to the list of content types.