### PR TITLE
adding github action to run tests with different ruby versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: "Running Tests"
+
+on:
+  - pull_request
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  RACK_ENV: test
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+        ruby: ['2.7', '3.0', '3.1', 'head']
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: false
+      
+      - run: gem install nokogiri
+      - run: bundle install
+      
+      - name: Running tests
+        run: bundle exec rake test

--- a/feedbag.gemspec
+++ b/feedbag.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha', '~> 0.12', '>= 0.12.0'
   s.add_development_dependency 'webmock', '~> 3'
   s.add_development_dependency 'byebug', '~> 11'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'test-unit'
 
   s.bindir = 'bin'
   # s.default_executable = %q{feedbag}


### PR DESCRIPTION
I noticed, that in previous [pull request](https://github.com/damog/feedbag/pull/27#issuecomment-1067304884) this gem had some issues on older ruby version. So I decided to add Github Action with ruby matrix to verify that behavior is consisent with different ruby versions.

I left only versions that still didn't reach EOL.

Tested this change in my own repository:
https://github.com/skatkov/feedbag/pull/1